### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ The   project  want  to  create  a streaming interface for OpenAI-compatible mod
 ### 2. **Project Setup**
    - **Installation:** 
      - Steps include cloning a GitHub repository and setting up a Python environment (with Python 3.11 and Poetry).
-     - Key dependencies are `FastAPI` and `pyautogen`.
+     - Key dependencies are `FastAPI` and `ag2`.
 
    - **Environment Variables:** 
      - An OpenAI API key is required, which should be stored in environment variables or an `.env` file.


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
